### PR TITLE
missing imports and wrong main class

### DIFF
--- a/docs/0/getting-started/index.html
+++ b/docs/0/getting-started/index.html
@@ -180,7 +180,7 @@ public class HelloResource {
     <span xmlns="http://www.w3.org/1999/xhtml" class="hl-tag">&lt;version&gt;</span>0.11<span xmlns="http://www.w3.org/1999/xhtml" class="hl-tag">&lt;/version&gt;</span>
 <span xmlns="http://www.w3.org/1999/xhtml" class="hl-tag">&lt;/parent&gt;</span></pre><p>Other required <code class="code">pom.xml</code>
             additions:</p><pre class="programlisting"><span xmlns="http://www.w3.org/1999/xhtml" class="hl-tag">&lt;properties&gt;</span>
-    <span xmlns="http://www.w3.org/1999/xhtml" class="hl-tag">&lt;main.class&gt;</span>com.foo.Application<span xmlns="http://www.w3.org/1999/xhtml" class="hl-tag">&lt;/main.class&gt;</span>
+    <span xmlns="http://www.w3.org/1999/xhtml" class="hl-tag">&lt;main.class&gt;</span>com.nhl.bootique.bom.Application<span xmlns="http://www.w3.org/1999/xhtml" class="hl-tag">&lt;/main.class&gt;</span>
 <span xmlns="http://www.w3.org/1999/xhtml" class="hl-tag">&lt;/properties&gt;</span>
 ...
 <span xmlns="http://www.w3.org/1999/xhtml" class="hl-tag">&lt;build&gt;</span>

--- a/docs/0/getting-started/index.html
+++ b/docs/0/getting-started/index.html
@@ -80,6 +80,8 @@
             class to tell Bootique where to find the
             resource:</p><pre class="programlisting"><span xmlns="http://www.w3.org/1999/xhtml" class="hl-keyword">package</span> com.nhl.bootique.bom;
 
+<span xmlns="http://www.w3.org/1999/xhtml" class="hl-keyword">import</span> com.foo.HelloResource;
+<span xmlns="http://www.w3.org/1999/xhtml" class="hl-keyword">import</span> com.google.inject.Module;
 <span xmlns="http://www.w3.org/1999/xhtml" class="hl-keyword">import</span> com.nhl.bootique.Bootique;
 <span xmlns="http://www.w3.org/1999/xhtml" class="hl-keyword">import</span> com.nhl.bootique.jersey.JerseyModule;
 


### PR DESCRIPTION
If someone follows the page [getting-started](http://bootique.io/docs/0/getting-started/index.html) step by step he will be faced with two small mistakes.

chapter 1
- the class `com.nhl.bootique.bom.Application` misses two import statements

chapter 4
- the value for main-class in the `pom.xml` is wrong