### PR TITLE
Applied skeletal implementation to interface migration automated refactoring

### DIFF
--- a/bootique/src/main/java/com/nhl/bootique/cli/Cli.java
+++ b/bootique/src/main/java/com/nhl/bootique/cli/Cli.java
@@ -41,7 +41,15 @@ public interface Cli {
 	 * @throws RuntimeException
 	 *             if there's more then one value for the option.
 	 */
-	String optionString(String name);
+	default String optionString(String name) {
+		List<String> allStrings = optionStrings(name);
+	
+		if (allStrings.size() > 1) {
+			throw new RuntimeException("More than one value specified for option: " + name);
+		}
+	
+		return allStrings.isEmpty() ? null : allStrings.get(0);
+	}
 
 	/**
 	 * Returns all arguments that are not options or option values in the order

--- a/bootique/src/main/java/com/nhl/bootique/env/DefaultEnvironment.java
+++ b/bootique/src/main/java/com/nhl/bootique/env/DefaultEnvironment.java
@@ -11,13 +11,6 @@ import java.util.Map;
  */
 public class DefaultEnvironment implements Environment {
 
-	public static final String FRAMEWORK_PROPERTIES_PREFIX = "bq";
-
-	/**
-	 * @since 0.17
-	 */
-	public static final String FRAMEWORK_VARIABLES_PREFIX = "BQ_";
-
 	/**
 	 * If present, enables boot sequence tracing to STDERR.
 	 */

--- a/bootique/src/main/java/com/nhl/bootique/env/DefaultEnvironment.java
+++ b/bootique/src/main/java/com/nhl/bootique/env/DefaultEnvironment.java
@@ -46,11 +46,6 @@ public class DefaultEnvironment implements Environment {
 	}
 
 	@Override
-	public Map<String, String> frameworkProperties() {
-		return subproperties(FRAMEWORK_PROPERTIES_PREFIX);
-	}
-
-	@Override
 	public String getVariable(String name) {
 		return variables.get(name);
 	}
@@ -58,11 +53,6 @@ public class DefaultEnvironment implements Environment {
 	@Override
 	public Map<String, String> variables(String prefix) {
 		return filterByPrefix(variables, prefix, "_");
-	}
-
-	@Override
-	public Map<String, String> frameworkVariables() {
-		return variables(FRAMEWORK_VARIABLES_PREFIX);
 	}
 
 	protected Map<String, String> filterByPrefix(Map<String, String> unfiltered, String prefix, String separator) {

--- a/bootique/src/main/java/com/nhl/bootique/env/Environment.java
+++ b/bootique/src/main/java/com/nhl/bootique/env/Environment.java
@@ -1,8 +1,5 @@
 package com.nhl.bootique.env;
 
-import static com.nhl.bootique.env.DefaultEnvironment.FRAMEWORK_PROPERTIES_PREFIX;
-import static com.nhl.bootique.env.DefaultEnvironment.FRAMEWORK_VARIABLES_PREFIX;
-
 import java.util.Map;
 
 /**
@@ -10,6 +7,13 @@ import java.util.Map;
  * Allows to filter properties by prefix to separate Bootique-specific values.
  */
 public interface Environment {
+
+	String FRAMEWORK_PROPERTIES_PREFIX = "bq";
+	
+	/**
+	 * @since 0.17
+	 */
+	String FRAMEWORK_VARIABLES_PREFIX = "BQ_";
 
 	String getProperty(String name);
 

--- a/bootique/src/main/java/com/nhl/bootique/env/Environment.java
+++ b/bootique/src/main/java/com/nhl/bootique/env/Environment.java
@@ -1,5 +1,8 @@
 package com.nhl.bootique.env;
 
+import static com.nhl.bootique.env.DefaultEnvironment.FRAMEWORK_PROPERTIES_PREFIX;
+import static com.nhl.bootique.env.DefaultEnvironment.FRAMEWORK_VARIABLES_PREFIX;
+
 import java.util.Map;
 
 /**
@@ -28,7 +31,9 @@ public interface Environment {
 	 * 
 	 * @return a map of all properties that start with "bq." prefix.
 	 */
-	Map<String, String> frameworkProperties();
+	default Map<String, String> frameworkProperties() {
+		return subproperties(FRAMEWORK_PROPERTIES_PREFIX);
+	}
 
 	/**
 	 * Returns a value of the environment variable with a given name.
@@ -58,5 +63,7 @@ public interface Environment {
 	 * @since 0.17
 	 * @return a map of all variables that start with "BQ_" prefix.
 	 */
-	Map<String, String> frameworkVariables();
+	default Map<String, String> frameworkVariables() {
+		return variables(FRAMEWORK_VARIABLES_PREFIX);
+	}
 }

--- a/bootique/src/main/java/com/nhl/bootique/jopt/JoptCli.java
+++ b/bootique/src/main/java/com/nhl/bootique/jopt/JoptCli.java
@@ -55,17 +55,6 @@ public class JoptCli implements Cli {
 		return optionSet.valuesOf(name).stream().map(o -> String.valueOf(o)).collect(toList());
 	}
 
-	@Override
-	public String optionString(String name) {
-		List<String> allStrings = optionStrings(name);
-
-		if (allStrings.size() > 1) {
-			throw new RuntimeException("More than one value specified for option: " + name);
-		}
-
-		return allStrings.isEmpty() ? null : allStrings.get(0);
-	}
-
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<String> standaloneArguments() {


### PR DESCRIPTION
This is a semantics-preserving automated refactoring that migrates existing method implementations in classes to the corresponding implemented interface methods as `default` methods. The tool **does not** add new code; it only rearranges *existing* code.

- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Migrate Skeletal Implementation to Interface](https://github.com/khatchad/Migrate-Skeletal-Implementation-to-Interface-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. That may mean that not all changes that can be made were made. Please feel free to continue the refactoring manually if you wish.
- We migrated methods declared in both abstract and concrete classes with the hopes of such methods being suitable default methods in corresponding interfaces.
- The source code should be semantically equivalent to the original.
- There was one manual change reversal due to an implementation stemming from a unit test that was too test specific.

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if *each* of the proposed changes are helpful or not.